### PR TITLE
add schema registry log level / overrides

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,11 +16,18 @@ class confluent_schema_registry::config (
   $request_logger_name                 = 'io.confluent.rest-utils.requests',
   $shutdown_graceful_ms                = '1000',
 ) {
-  file { '/etc/schema-registry/schema-registry.properties':
-    content => template('confluent_schema_registry/schema-registry.properties.erb'),
-    owner   => 'schema-registry',
-    group   => 'schema-registry',
-    mode    => '0644',
-    notify  => Service['schema-registry'],
+  file { 
+    '/etc/schema-registry/schema-registry.properties':
+      content => template('confluent_schema_registry/schema-registry.properties.erb'),
+      owner   => 'schema-registry',
+      group   => 'schema-registry',
+      mode    => '0644',
+      notify  => Service['schema-registry'];
+    '/etc/schema-registry/log4j.properties':
+      content => template('confluent_schema_registry/log4j.properties.erb'),
+      owner   => 'schema-registry',
+      group   => 'schema-registry',
+      mode    => '0644',
+      notify  => Service['schema-registry'];
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,12 @@
 class confluent_schema_registry (
-  $version                   = '1.0.1-2',
+  $version                     = '1.0.1-2',
+  $app_log_dir                 = '/var/log/schema-registry',
+  # logger levels
+  $kafka_loglevel              = 'INFO',
+  $apache_zookeeper_loglevel   = 'WARN',
+  $apache_kafka_loglevel       = 'WARN',
+  $zkclient_loglevel           = 'WARN',
+  $consumer_connector_loglevel = 'WARN',
 ) {
   class { 'confluent_schema_registry::install': } ->
   class { 'confluent_schema_registry::config': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,8 +38,15 @@ class confluent_schema_registry::install {
     require => Group['schema-registry'],
   }
 
-  file { '/etc/init.d/schema-registry':
-    source => 'puppet:///modules/confluent_schema_registry/schema-registry.init',
-    mode   => '0755',
+  file { 
+    '/etc/init.d/schema-registry':
+      source => 'puppet:///modules/confluent_schema_registry/schema-registry.init',
+      mode   => '0755';
+    $::confluent_schema_registry::app_log_dir:
+      ensure  => directory,
+      owner   => 'schema-registry',
+      group   => 'schema-registry',
+      mode    => '0755',
+      require => Package['confluent-schema-registry'];
   }
 }

--- a/templates/log4j.properties.erb
+++ b/templates/log4j.properties.erb
@@ -1,0 +1,23 @@
+# managed by puppet
+schema-registry.logs.dir=<%= scope.lookupvar('confluent_schema_registry::app_log_dir') %>
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.maxBackupIndex=10
+log4j.appender.file.maxFileSize=100MB
+log4j.appender.file.File=${schema-registry.logs.dir}/schema-registry.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.logger.kafka=<%= scope.lookupvar('confluent_schema_registry::kafka_loglevel') %>, file
+log4j.logger.org.apache.zookeeper=<%= scope.lookupvar('confluent_schema_registry::apache_zookeeper_loglevel') %>, file
+log4j.logger.org.apache.kafka=<%= scope.lookupvar('confluent_schema_registry::apache_kafka_loglevel') %>, file
+log4j.logger.org.I0Itec.zkclient=<%= scope.lookupvar('confluent_schema_registry::zkclient_loglevel') %>, file
+log4j.logger.kafka.consumer.ZookeeperConsumerConnector=<%= scope.lookupvar('confluent_schema_registry::consumer_connector_loglevel') %>, file
+log4j.additivity.kafka.server=false
+log4j.additivity.kafka.consumer.ZookeeperConsumerConnector=false


### PR DESCRIPTION
Schema registry was only set to log to stdout by the confluent packages - this sets logging to a log file.