### PR TITLE
DIN-3012 add jmx-opts argument

### DIFF
--- a/files/schema-registry.init
+++ b/files/schema-registry.init
@@ -19,8 +19,12 @@ SCHEMA_REGISTRY_GROUP=schema-registry
 SCHEMA_REGISTRY_PID="/var/run/$NAME.pid"
 
 export JMX_PORT=9998
-export SCHEMA_REGISTRY_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT"
-
+export SCHEMA_REGISTRY_JMX_OPTS="-Dcom.sun.management.jmxremote \
+-Dcom.sun.management.jmxremote.authenticate=false \
+-Dcom.sun.management.jmxremote.ssl=false \
+-Dcom.sun.management.jmxremote.local.only=false \
+-Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT \
+-javaagent:/opt/jmx-prometheus-javaagent/bin/jmx_prometheus_javaagent-0.20.0.jar=7072:/etc/jmx-prometheus/schema-registry-jmx-exporter.yaml"
 
 # Make sure schema-registry is started with system locale
 if [ -r /etc/default/locale ]; then

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class confluent_schema_registry (
   $consumer_connector_loglevel = 'WARN',
   $zk_namespace                = undef,
   $group_id                    = undef,
+  $jmx_opts                    = undef,
 ) {
   class { 'confluent_schema_registry::install': }
   -> class { 'confluent_schema_registry::config':  }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -64,9 +64,17 @@ class confluent_schema_registry::install {
     require => Group['schema-registry'],
   }
 
+
+  if $::confluent_schema_registry::jmx_opts != undef and $::confluent_schema_registry::jmx_opts != '' {
+    $jmx_opts = $::confluent_schema_registry::jmx_opts
+    notify { "JMX_OPTS: ${jmx_opts}": }
+  }
+
   file {
     '/etc/init.d/schema-registry':
-      source => 'puppet:///modules/confluent_schema_registry/schema-registry.init',
+      content => template('confluent_schema_registry/schema-registry.init.erb'),
+      owner   => 'schema-registry',
+      group   => 'schema-registry',
       mode   => '0755';
     $::confluent_schema_registry::app_log_dir:
       ensure  => directory,

--- a/templates/schema-registry.init.erb
+++ b/templates/schema-registry.init.erb
@@ -18,13 +18,9 @@ SCHEMA_REGISTRY_GROUP=schema-registry
 
 SCHEMA_REGISTRY_PID="/var/run/$NAME.pid"
 
-export JMX_PORT=9998
-export SCHEMA_REGISTRY_JMX_OPTS="-Dcom.sun.management.jmxremote \
--Dcom.sun.management.jmxremote.authenticate=false \
--Dcom.sun.management.jmxremote.ssl=false \
--Dcom.sun.management.jmxremote.local.only=false \
--Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT \
--javaagent:/opt/jmx-prometheus-javaagent/bin/jmx_prometheus_javaagent-0.20.0.jar=7072:/etc/jmx-prometheus/schema-registry-jmx-exporter.yaml"
+<% if @jmx_opts -%>
+JMX_OPTS=<%= @jmx_opts %>
+<% end -%>
 
 # Make sure schema-registry is started with system locale
 if [ -r /etc/default/locale ]; then


### PR DESCRIPTION
Editing this module slightly to accept jmx opts externally. It's between this or having static configs inside this module that we'll have to keep in sync with the ones in puppetserver-environments, which would be a pain both in terms of preventing the breaking of things and also figuring out how things are working.