### PR TITLE
NT change default for kafkastore_init_timeout_ms

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class confluent_schema_registry::config (
   $kafkastore_topic                    = '_schemas',
   $kafkastore_topic_replication_factor = '3',
   $kafkastore_commit_interval_ms       = '-1',
-  $kafkastore_init_timeout_ms          = '5000',
+  $kafkastore_init_timeout_ms          = '60000',
   $kafkastore_timeout_ms               = '500',
   $kafkastore_zk_session_timeout_ms    = '10000',
   $avro_compatibility_level            = 'full',


### PR DESCRIPTION
The value of 5000 is far below the default value of 60000 as shown in [the confluent documentation](https://docs.confluent.io/platform/current/schema-registry/installation/config.html#kafkastore-init-timeout-ms). 

**Why is this change needed?**
This timeout is essentially the time allowed to load the kafkastore topic, which in our case is `_schemas`. If it can't load it within the allowed time then startup will fail with an error similar to the one below. The `_schemas` can definitely take upwards of 5 seconds to consume and so this change is needed.

```
[2024-08-02 10:24:22,676] ERROR Error starting the schema registry (io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication)
io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryInitializationException: Error initializing kafka store while initializing schema registry
        at io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry.init(KafkaSchemaRegistry.java:214)
        at io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication.setupResources(SchemaRegistryRestApplication.java:56)
        at io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication.setupResources(SchemaRegistryRestApplication.java:38)
        at io.confluent.rest.Application.createServer(Application.java:157)
        at io.confluent.kafka.schemaregistry.rest.SchemaRegistryMain.main(SchemaRegistryMain.java:43)
Caused by: io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException: io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException: KafkaStoreReaderThread failed to reach target offset within the timeout interval. targetOffset: 7937, offsetReached: 7860, timeout(ms): 5000
        at io.confluent.kafka.schemaregistry.storage.KafkaStore.init(KafkaStore.java:181)
        at io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry.init(KafkaSchemaRegistry.java:212)
        ... 4 more
Caused by: io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException: KafkaStoreReaderThread failed to reach target offset within the timeout interval. targetOffset: 7937, offsetReached: 7860, timeout(ms): 5000
        at io.confluent.kafka.schemaregistry.storage.KafkaStoreReaderThread.waitUntilOffset(KafkaStoreReaderThread.java:257)
        at io.confluent.kafka.schemaregistry.storage.KafkaStore.waitUntilKafkaReaderReachesLastOffset(KafkaStore.java:406)
        at io.confluent.kafka.schemaregistry.storage.KafkaStore.init(KafkaStore.java:179)
        ... 5 more
```